### PR TITLE
Rebuild for pari-gmp on osx-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: aaa017a6a280581902f73cf5ce1695712b6598a032be14cfab81f97c475f83b8
 
 build:
-  number: 0
+  number: 1
   # cypari2 is generally compatible with Python 3.8 (but 2.1.3 and 2.1.4 have problems with that Python.)
   skip: true  # [win or py<39]
   script:


### PR DESCRIPTION
This fixes

```
ImportError: dlopen(/Users/runner/work/sage-flatsurf/sage-flatsurf/sage-flatsurf-0.7.4.post47/sage-flatsurf/.pixi/envs/dev/lib/python3.12/site-packages/cypari2/pari_instance.cpython-312-darwin.so, 0x0002): Library not loaded: @rpath/libpari-tls.dylib
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
